### PR TITLE
Migrate from `pykalman` to `pykalman-bardo`

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 -r requirements.txt
 -r requirements-doc.txt
 
-pykalman==0.9.5  # for testing purposes
+pykalman-bardo==0.9.6  # for testing purposes
 pytest==5.0.1
 isort
 black

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 -r requirements.txt
 -r requirements-doc.txt
 
-pykalman-bardo==0.9.6  # for testing purposes
+pykalman-bardo==0.9.7  # for testing purposes
 pytest==5.0.1
 isort
 black


### PR DESCRIPTION
Consider migration from `pykalman` to `pykalman-bardo`, as [pykalman](https://github.com/pykalman/pykalman) project is no longer maintained. There were some issues that were fixed, see: https://github.com/pybardo/pykalman/blob/v0.9.7/CHANGELOG

I'm going to maintain [pykalman-bardo](https://github.com/pybardo/pykalman), react to issues, and fix bugs. For now the API is the same as in the initial package, but it might evolve in time.

I hope you will find it useful for your project!